### PR TITLE
Add note for PHP extensions in php.ini

### DIFF
--- a/en/requirements.rst
+++ b/en/requirements.rst
@@ -40,6 +40,14 @@ Sonerezh is cooked with CakePHP, and you need PHP to be installed.
 * PHP >= 5.4
 * PHP-GD PHP module
 
+Ensure the required PHP extensions are enabled in your php.ini:
+
+.. code-block:: text
+    
+    extension=exif.so
+    extension=gd.so
+    extension=pdo_mysql.so
+
 -----------------
 Libav (optional)
 -----------------
@@ -48,6 +56,6 @@ You need to install libav-tools if you want Sonerezh to convert your tracks to a
 
 On Debian :
 
-.. code-block:: sh
+.. code-block:: text
 
     sudo apt-get install libav-tools

--- a/en/requirements.rst
+++ b/en/requirements.rst
@@ -56,6 +56,6 @@ You need to install libav-tools if you want Sonerezh to convert your tracks to a
 
 On Debian :
 
-.. code-block:: text
+.. code-block:: sh
 
     sudo apt-get install libav-tools

--- a/fr/requirements.rst
+++ b/fr/requirements.rst
@@ -40,6 +40,14 @@ Sonerezh fonctionne avec le framework PHP CakePHP, PHP est donc indispensable.
 * PHP 5.4 ou supérieur
 * Le module PHP GD
 
+Veuillez vérifier que les extensions PHP requises sont bien activées dans votre php.ini:
+
+.. code-block:: text
+    
+    extension=exif.so
+    extension=gd.so
+    extension=pdo_mysql.so
+
 -----------------
 Libav (optionnel)
 -----------------


### PR DESCRIPTION
While installing I struggled with some missing php extensions, for example I needed to enable exif/gd support to see album cover art after the database import. Just thought a little note about these extensions would be nice.
